### PR TITLE
Fix an issue where Haskell code was being escaped

### DIFF
--- a/bin/split-hsfiles
+++ b/bin/split-hsfiles
@@ -23,6 +23,6 @@ while read -r line; do
     current_file="input/${name}/${start_file_result%*$end_file_syntax}"
     mkdir -p "$(dirname "$current_file")"
   else
-    echo "$line" >> "${current_file}"
+    printf "%s\n" "$line" >> "${current_file}"
   fi
 done < "${name}.hsfiles"


### PR DESCRIPTION
Previously, `echo` would escape the Haskell code being printed to the
file, so a lambda expression like `\tid -> whatever` would replace the
`\t` with a tab character. This commit fixes that by printing the code
literally.
