### PR TITLE
Clarify usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Custom templates for [Stack] used by thoughtbot.
 
 Usage:
 
-    stack new https://raw.githubusercontent.com/thoughtbot/stack-templates/master/yesod-heroku.hsfiles
+    stack new my-project https://raw.githubusercontent.com/thoughtbot/stack-templates/master/yesod-heroku.hsfiles
 
 Initializes a new Yesod project ready to deploy to Heroku.
 


### PR DESCRIPTION
Why:

Copying and pasting the usage command in the README doesn't work.

This PR:

Clarifies that you need to provide a project name when running stack
new.
